### PR TITLE
Fix response for Lambda for ALB target group

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ gcloud app deploy --project=jira-to-slack appengine/app.yaml
 
 ### Lambda
 
-You can deploy the application to AWS Lambda.
+You can deploy the application to AWS Lambda and API Gateway.
 
 ```sh
 # Run
@@ -112,6 +112,16 @@ make -C lambda deploy SAM_S3_BUCKET_NAME=YOUR_BUCKET_NAME
 ```
 
 You need to create a S3 bucket in the same region before deploying.
+
+If you want to deploy the application to AWS Lambda and ALB Target Group,
+you need to change the request and response types as follows:
+
+```sh
+sed -i \
+  -e s/APIGatewayProxyRequest/ALBTargetGroupRequest/g \
+  -e s/APIGatewayProxyResponse/ALBTargetGroupResponse/g \
+  lambda/main.go
+```
 
 
 ## How it works

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -17,13 +17,14 @@ func handleIndex(_ context.Context, r events.APIGatewayProxyRequest) (events.API
 	params, err := handlers.ParseWebhookParams(r.MultiValueQueryStringParameters)
 	if err != nil {
 		return events.APIGatewayProxyResponse{
-			StatusCode: http.StatusBadRequest,
-			Body:       err.Error(),
+			StatusCode: http.StatusOK,
+			Headers:    map[string]string{"content-type": "text/plain"},
+			Body:       fmt.Sprintf("OK\n%s", err.Error()),
 		}, nil
 	}
 	return events.APIGatewayProxyResponse{
 		StatusCode: http.StatusOK,
-		Body:       fmt.Sprintf("Parameter=%+v", params),
+		Body:       fmt.Sprintf("OK\nreceived the parameters: %+v", params),
 	}, nil
 }
 
@@ -32,6 +33,7 @@ func handleWebhook(ctx context.Context, r events.APIGatewayProxyRequest) (events
 	if err != nil {
 		return events.APIGatewayProxyResponse{
 			StatusCode: http.StatusBadRequest,
+			Headers:    map[string]string{"content-type": "text/plain"},
 			Body:       err.Error(),
 		}, nil
 	}
@@ -39,6 +41,7 @@ func handleWebhook(ctx context.Context, r events.APIGatewayProxyRequest) (events
 	if err := json.Unmarshal([]byte(r.Body), &event); err != nil {
 		return events.APIGatewayProxyResponse{
 			StatusCode: http.StatusBadRequest,
+			Headers:    map[string]string{"content-type": "text/plain"},
 			Body:       fmt.Sprintf("could not decode json of response body: %s", err),
 		}, nil
 	}
@@ -53,11 +56,13 @@ func handleWebhook(ctx context.Context, r events.APIGatewayProxyRequest) (events
 	if err := u.Do(ctx, in); err != nil {
 		return events.APIGatewayProxyResponse{
 			StatusCode: http.StatusInternalServerError,
+			Headers:    map[string]string{"content-type": "text/plain"},
 			Body:       err.Error(),
 		}, nil
 	}
 	return events.APIGatewayProxyResponse{
 		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"content-type": "text/plain"},
 		Body:       "OK",
 	}, nil
 }


### PR DESCRIPTION
This will fix the issue that health check fails when a Lambda is attached to an ALB target group.